### PR TITLE
Allow return empty deployment id

### DIFF
--- a/src/Tool.php
+++ b/src/Tool.php
@@ -973,7 +973,7 @@ class Tool
         $this->platform->signatureMethod = reset($platformConfig['id_token_signing_alg_values_supported']);
         $this->platform->platformId = $platformConfig['issuer'];
         $this->platform->clientId = $registrationConfig['client_id'];
-        $this->platform->deploymentId = $registrationConfig['https://purl.imsglobal.org/spec/lti-tool-configuration']['deployment_id'];
+        $this->platform->deploymentId = $registrationConfig['https://purl.imsglobal.org/spec/lti-tool-configuration']['deployment_id'] ?? '';
         $this->platform->authenticationUrl = $platformConfig['authorization_endpoint'];
         $this->platform->accessTokenUrl = $platformConfig['token_endpoint'];
         $this->platform->jku = $platformConfig['jwks_uri'];


### PR DESCRIPTION
Hi! 

There are some LMS like Canvas that doesn't return the deployment_id on registration

You can see there is not returned on 
https://canvas.instructure.com/doc/api/file.registration.html#lti-tool-configuration-schema


Then if is not send we leave at empty, then we have to enable it 
Thanks!


